### PR TITLE
Adding updated scripts

### DIFF
--- a/Scripts/Connector/Sample connector cleanup script.ps1
+++ b/Scripts/Connector/Sample connector cleanup script.ps1
@@ -21,28 +21,23 @@
 #==========================================================================
 
 
-<# param(
+param(
     [Parameter(Position=0, Mandatory=$true)]
     [string]$ConnectorName
 )
- #>
 
-# CleanupConnector $ConnectorName
+# Install the required module by running Install-Module "UniversalPrintManagement"
+#Requires -Modules "UniversalPrintManagement"
 
 function CleanupConnector {
     Param(
-    [Parameter(Mandatory=$true)]
-    [string] $ConnectorName
+        [Parameter(Mandatory=$true)]
+        [string] $ConnectorName
     )
 
     Write-Host "Checking for elevated permissions..."
     if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    throw "Insufficient permissions to run this script. Open the PowerShell console as an administrator and run this script again."
-    }
-
-    Write-Host "Checking if Universal Print Powershell module is installed..."
-    if (-NOT (Get-InstalledModule -Name UniversalPrintManagement)) {
-        throw "Please install the Universal Print Powershell module (UniversalPrintManagement) before proceeding further."
+        throw "Insufficient permissions to run this script. Open the PowerShell console as an administrator and run this script again."
     }
 
     # Warn the user; these actions are not recoverable
@@ -53,9 +48,10 @@ function CleanupConnector {
     # Ensure that the connector name provided is same as the connector installed on this machine
     if ($LocalConnector.Name -ne $ConnectorName) {
 
+    # Format the error messae. Avoid whitespace as those will show up in actual message.
     $errorMessage=@"
-    The locally installed connector $($LocalConnectorName) does not match the name provided to this script $($ConnectorName).
-    `nYou must run this script on the same machine as the connector that is to be cleaned up.
+The locally installed connector $($LocalConnectorName) does not match the name provided to this script $($ConnectorName).
+`nYou must run this script on the same machine as the connector that is to be cleaned up.
 "@
 
     throw $errorMessage
@@ -121,3 +117,6 @@ function CleanupConnector {
         Get-ChildItem -Path $env:ProgramData\Microsoft\UniversalPrintConnector -EA SilentlyContinue | Remove-Item -Recurse -Force
     }
 }
+
+## Invoke the main method
+#CleanupConnector $ConnectorName

--- a/Scripts/Connector/Sample register local printers with Universal Print script.ps1
+++ b/Scripts/Connector/Sample register local printers with Universal Print script.ps1
@@ -1,0 +1,119 @@
+#
+# Version 1.0
+#
+#========================== IMPORTANT DISCLAIMER ==========================
+# PLEASE DO NOT RUN THIS SCRIPT IN A PRODUCTION ENVIRONMENT.
+# This script is provided as a sample for reference purposes only.
+# Please read it and create your own script.
+#==========================================================================
+#
+# Register local printers with Universal Print.
+# 
+# The script will enumerate locally installed printers that can be registered with Universal Print,
+# and call the Universal Print Connector service (running locally) to register the printer with 
+# Universal Print service.
+# 
+# This script automates the process of logging into the PrintConnectorApp, selecting all printers, 
+# and clicking the Register button.
+#
+# Run the script locally using an elevated Powershell window, from the same machine that has the 
+# Universal Print Connector installed.
+
+# Install the required module by running Install-Module "Microsoft.Identity.Client"
+#Requires -Modules "Microsoft.Identity.Client"
+
+Import-Module "Microsoft.Identity.Client"
+
+function Get-ConnectorServiceUri 
+{
+    $servicePort = Get-ItemPropertyValue -path HKLM:SOFTWARE\Microsoft\UniversalPrint\Connector -Name ServicePort
+    $uri = "http://localhost:$servicePort/WindowsServiceHostedService/PrinterConnectorService?wsdl"
+    return $uri;
+}
+
+function Get-LocalPrintersFromConnector($ConnectorService)
+{
+    return $ConnectorService.GetLocalUnregisteredPrintersWithDeviceId()
+}
+
+function Get-PublicClientApplication
+{
+    # Universal Print Connector's client id to retrieve an AAD authentication token
+    $ClientId = "80331ee5-4436-4815-883e-93bc833a9a15"
+    $Authority = "https://login.microsoftonline.com/common"
+    $RedirectUri = "https://UniversalPrintConnector"
+    $pcaConfig = [Microsoft.Identity.Client.PublicClientApplicationBuilder]::Create($ClientId).WithAuthority($Authority).WithRedirectUri($RedirectUri)
+    return $pcaConfig.Build();
+}
+
+function Register-LocalPrinterWithUP($ConnectorService, $PrinterName, $PrinterDeviceId, $Token)
+{
+    Write-Host Registering printer $PrinterName
+    $result = $false
+    $resultSpecified = $false
+    $ConnectorService.RegisterPrinter($printerName, $PrinterDeviceId, "printer", $Token, [ref] $result, [ref] $resultSpecified)
+    if ($result)
+    {
+        Write-Host "Successfully registered printer $PrinterName"
+    }
+    else
+    {
+        Write-Error "Failed to register $PrinterName printer. Please check the Event Viewer Log for details."
+    }
+}
+
+function Invoke-Main
+{
+    $ConnectorServiceUri = Get-ConnectorServiceUri
+    $ConnectorService = New-WebServiceProxy -Uri $ConnectorServiceUri -UseDefaultCredential
+
+    # Ensure Connector is registered
+    $isConnectorRegistered = $false;
+    $isConnectorRegisteredSpecified = $false;
+    $ConnectorService.IsConnectorRegistered([ref] $isConnectorRegistered, [ref] $isConnectorRegisteredSpecified)
+    if (!$isConnectorRegistered)
+    {
+        Write-Error "Connector needs to be registered first. Please use the Print Connector App to register the Connector." -ErrorAction Stop
+    }
+
+    # Get local printers (not yet registered with UP) from the Connector service
+    Write-Host "Getting list of printers from the Universal Print Connector"
+    $localPrinters = Get-LocalPrintersFromConnector -ConnectorService $ConnectorService
+    if ($localPrinters -eq $null)
+    {
+        Write-Host "No local printer available to register. Please see the Event Viewer Log for any printers that were filtered out and unsupported."
+        return
+    }
+    
+    $scope = "https://print.print.microsoft.com/.default";
+    $scopes = New-Object System.Collections.Generic.List[string]
+    $scopes.Add($scope)
+
+    $publicClientApplication = Get-PublicClientApplication
+    $account = $null
+    foreach ($printer in $localPrinters)
+    {
+        # Refresh the existing token or get a new AAD auth token.
+        Write-Host "Ensuring a valid AAD authentication token exists"
+
+        if ($account -ne $null)
+        {
+            $authResult = $publicClientApplication.AcquireTokenSilent($scopes, $account).ExecuteAsync().Result
+        }
+    
+        # Else if we don't have a valid account or if the silent call fails, get the token interactively
+        if ($authResult -eq $null)
+        {
+            $authResult = $publicClientApplication.AcquireTokenInteractive($scopes).ExecuteAsync().Result
+        }
+    
+        # Cache the account for subsequent usage
+        $account = $authResult.Account
+
+        # Register the given printer with UP
+        Register-LocalPrinterWithUP -ConnectorService $ConnectorService -PrinterName $printer.m_Item1 -PrinterDeviceId $printer.m_Item2 -Token $authResult.AccessToken
+    }
+}
+
+## Invoke the main method
+# Invoke-Main

--- a/Scripts/Connector/Sample reset registered printer script.ps1
+++ b/Scripts/Connector/Sample reset registered printer script.ps1
@@ -1,0 +1,52 @@
+#
+# Version 1.0
+#
+#========================== IMPORTANT DISCLAIMER ==========================
+# PLEASE DO NOT RUN THIS SCRIPT IN A PRODUCTION ENVIRONMENT.
+# This script is provided as a sample for reference purposes only.
+# Please read it and create your own script.
+#==========================================================================
+#
+# Reset a printer that is registered with Universal Print.
+# 
+# The script can help reset an existing printer that is registered with Universal Print. If the printer
+# is having issues printing successfully, or showing the correct printer status, resetting it may help
+# clear the issue. This is similar to restarting the Print Connector service or restarting the machine.
+#
+# Run the script locally using an elevated Powershell window, from the same machine that has the 
+# Universal Print Connector installed.
+
+param(
+    [Parameter(Position=0, Mandatory=$true)]
+    [string]$PrinterName
+)
+
+function Get-ConnectorServiceUri 
+{
+    $servicePort = Get-ItemPropertyValue -path HKLM:SOFTWARE\Microsoft\UniversalPrint\Connector -Name ServicePort
+    $uri = "http://localhost:$servicePort/WindowsServiceHostedService/PrinterConnectorService?wsdl"
+    return $uri;
+}
+
+function Invoke-Main
+{
+    $ConnectorServiceUri = Get-ConnectorServiceUri
+    $ConnectorService = New-WebServiceProxy -Uri $ConnectorServiceUri -UseDefaultCredential
+
+    # Ensure Connector is registered
+    $isConnectorRegistered = $false;
+    $isConnectorRegisteredSpecified = $false;
+    $ConnectorService.IsConnectorRegistered([ref] $isConnectorRegistered, [ref] $isConnectorRegisteredSpecified)
+    if (!$isConnectorRegistered)
+    {
+        Write-Error "Connector needs to be registered first. Please use the Print Connector App to register the Connector." -ErrorAction Stop
+    }
+
+    # Reset the given printer
+    $ConnectorService.ResetPrinterAsync($PrinterName);
+    
+    Write-Host "Check PrintConnector event logs to verify if the printer is reset and initialized successfully."
+}
+
+## Invoke the main method
+#Invoke-Main


### PR DESCRIPTION
* Adding updated script for cleaning up existing (registered) Connector 
* Adding a new script to help with registering local printers (already installed on the Connector machine)
* Adding a new script to help with resetting an existing printer registered with Universal Print. This helps when the printer is not processing print jobs as expected, not updating printer status, or the driver was updated locally on the Connector. Instead of restarting the Print Connector service (and impacting all users/printers on the Connector), the individual printer(s) can be reset.